### PR TITLE
Reduce CPU usage when UI is static - native animations fix

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -1014,7 +1014,6 @@ void pxObject::animateToInternal(const char* prop, double to, double duration,
   mAnimations.push_back(a);
 
   markBranchDirty();
-
   pxAnimate *animObj = (pxAnimate *)a.animateObj.getPtr();
 
   if (NULL != animObj)
@@ -1765,7 +1764,6 @@ bool pxObject::onTextureReady()
   #ifdef PX_DIRTY_RECTANGLES
   mIsDirty = true;
   markBranchDirty();
-
   #endif //PX_DIRTY_RECTANGLES
   return false;
 }
@@ -3793,7 +3791,6 @@ rtError pxScriptView::setPermissions(const rtObjectRef& v)
   }
   return RT_FAIL;
 }
-
 void pxObject::markBranchDirty() {
   if (!mIsTreeDirty) {
     mIsTreeDirty = true;
@@ -3817,5 +3814,4 @@ void pxRoot::markBranchDirty() {
     pxObject::markBranchDirty();
   }
 }
-
 #endif

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -1047,7 +1047,6 @@ void pxObject::update(double t)
       }
     }
   } updateTree(this) ;
-
   // Update animations
   vector<animation>::iterator it = mAnimations.begin();
 

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -702,7 +702,9 @@ public:
      return RT_OK;
   }
 
+#ifdef PX_DIRTY_RECTANGLES
   virtual void markBranchDirty();
+#endif
 public:
   rtEmitRef mEmit;
 
@@ -769,7 +771,6 @@ class pxRoot: public pxObject
   rtDeclareObject(pxRoot, pxObject);
 public:
   pxRoot(pxScene2d* scene): pxObject(scene) {}
-  virtual void markBranchDirty();
 };
 
 class pxViewContainer: public pxObject, public pxIViewContainer

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -158,6 +158,7 @@ class pxFontManager;
 class pxObject: public rtObject
 {
 public:
+
   rtDeclareObject(pxObject, rtObject);
   rtReadOnlyProperty(_pxObject, _pxObject, voidPtr);
   rtProperty(parent, parent, setParent, rtObjectRef);
@@ -702,6 +703,8 @@ public:
      return RT_OK;
   }
 
+  virtual void markBranchDirty();
+
 public:
   rtEmitRef mEmit;
 
@@ -768,6 +771,7 @@ class pxRoot: public pxObject
   rtDeclareObject(pxRoot, pxObject);
 public:
   pxRoot(pxScene2d* scene): pxObject(scene) {}
+  virtual void markBranchDirty();
 };
 
 class pxViewContainer: public pxObject, public pxIViewContainer
@@ -996,6 +1000,7 @@ static int pxSceneContainerCount = 0;
 class pxSceneContainer: public pxViewContainer
 {
 public:
+
   rtDeclareObject(pxSceneContainer, pxViewContainer);
   rtProperty(url, url, setUrl, rtString);
 #ifdef ENABLE_PERMISSIONS_CHECK
@@ -1147,6 +1152,10 @@ public:
     return mEmit->delListener(eventName, f);
   }
   
+  pxIViewContainer* getViewContainer() {
+    return mViewContainer;
+  }
+
 protected:
 
   static rtError getScene(int /*numArgs*/, const rtValue* /*args*/, rtValue* result, void* ctx);
@@ -1564,6 +1573,10 @@ public:
   rtError getService(rtString name, rtObjectRef& returnObject);
   rtError getService(const char* name, const rtObjectRef& ctx, rtObjectRef& service);
   rtError getAvailableApplications(rtString& availableApplications);
+
+  pxScriptView* getScriptView() {
+    return mScriptView;
+  }
 
 private:
   bool bubbleEvent(rtObjectRef e, rtRef<pxObject> t, 

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -158,7 +158,6 @@ class pxFontManager;
 class pxObject: public rtObject
 {
 public:
-
   rtDeclareObject(pxObject, rtObject);
   rtReadOnlyProperty(_pxObject, _pxObject, voidPtr);
   rtProperty(parent, parent, setParent, rtObjectRef);
@@ -1000,7 +999,6 @@ static int pxSceneContainerCount = 0;
 class pxSceneContainer: public pxViewContainer
 {
 public:
-
   rtDeclareObject(pxSceneContainer, pxViewContainer);
   rtProperty(url, url, setUrl, rtString);
 #ifdef ENABLE_PERMISSIONS_CHECK

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -703,7 +703,6 @@ public:
   }
 
   virtual void markBranchDirty();
-
 public:
   rtEmitRef mEmit;
 
@@ -1153,7 +1152,6 @@ public:
   pxIViewContainer* getViewContainer() {
     return mViewContainer;
   }
-
 protected:
 
   static rtError getScene(int /*numArgs*/, const rtValue* /*args*/, rtValue* result, void* ctx);
@@ -1575,7 +1573,6 @@ public:
   pxScriptView* getScriptView() {
     return mScriptView;
   }
-
 private:
   bool bubbleEvent(rtObjectRef e, rtRef<pxObject> t, 
                    const char* preEvent, const char* event) ;


### PR DESCRIPTION
[ONEM-6906] reduce CPU usage when UI is static

Check for node running animations & mark the nodes dirty
if there are still some running
also, propagate mIsTreeDirty through pxSceneContainer objects