### PR TITLE
Avoid extra invocation of downloadUI task on main thread

### DIFF
--- a/examples/pxScene2d/src/pxArchive.cpp
+++ b/examples/pxScene2d/src/pxArchive.cpp
@@ -171,7 +171,6 @@ rtError pxArchive::initFromUrl(const rtString& url, const rtString& origin)
         }
         if( i >= node_path.c ) {
             mLoadStatus.set("statusCode",1);
-            gUIThreadQueue->addTask(pxArchive::onDownloadCompleteUI,this,NULL);
         }
     }
     else


### PR DESCRIPTION
This is causing the heap after free issue, because archive object reference count got decremented twice